### PR TITLE
Fix parsing spread operator on `require()`

### DIFF
--- a/sloppy-require-parser.js
+++ b/sloppy-require-parser.js
@@ -20,7 +20,7 @@ function parseCJS (src, result) {
       continue
     }
 
-    if (newWord(src, i) && !inComment(src, i)) {
+    if ((newWord(src, i) || isSpread(src, i)) && !inComment(src, i)) {
       const suffix = src.slice(i + 7)
       const m = suffix.match(CALL_WITH_STRING)
 
@@ -58,6 +58,11 @@ function parseCJS (src, result) {
 function newWord (src, i) {
   const s = i > 0 ? src.slice(i - 1, i) : ''
   return !/^\w|["'`._]/.test(s)
+}
+
+function isSpread (src, i) {
+  const s = i > 0 ? src.slice(i - 3, i) : ''
+  return s === '...'
 }
 
 function inComment (src, i) {

--- a/test.mjs
+++ b/test.mjs
@@ -37,10 +37,14 @@ test('basic module', function (t) {
 test('spread require output', function (t) {
   const res = parse(`
       const b = [...require("./def/pear" )]
+      const c = { ...require("./obj" ) }
+      const d = {
+        ...require("./newline-obj" )
+      }
     `, 'script')
 
   t.is(res.type, 'script')
-  t.alike(res.resolutions.map(r => r.input), ['./def/pear'])
+  t.alike(res.resolutions.map(r => r.input), ['./def/pear', './obj', './newline-obj'])
 })
 
 test('script that falls back', function (t) {

--- a/test.mjs
+++ b/test.mjs
@@ -34,6 +34,15 @@ test('basic module', function (t) {
   t.alike(res.resolutions.map(r => r.input), ['world', 'dynamic'])
 })
 
+test('spread require output', function (t) {
+  const res = parse(`
+      const b = [...require("./def/pear" )]
+    `, 'script')
+
+  t.is(res.type, 'script')
+  t.alike(res.resolutions.map(r => r.input), ['./def.pear'])
+})
+
 test('script that falls back', function (t) {
   const res = parse(`
     import hello from 'world'

--- a/test.mjs
+++ b/test.mjs
@@ -40,7 +40,7 @@ test('spread require output', function (t) {
     `, 'script')
 
   t.is(res.type, 'script')
-  t.alike(res.resolutions.map(r => r.input), ['./def.pear'])
+  t.alike(res.resolutions.map(r => r.input), ['./def/pear'])
 })
 
 test('script that falls back', function (t) {


### PR DESCRIPTION
The following fails to be parsed:

```js
const d = [...require('./dep/pear')]
```

This PR is starting with an example test and will update with a fix.